### PR TITLE
Don't require users to type paw when starting a shell

### DIFF
--- a/app/terminal/shell.py
+++ b/app/terminal/shell.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 
 from aioconsole import ainput
 
@@ -29,30 +30,35 @@ class Shell:
                     await self.session.refresh()
                     commands = {
                         'help': lambda _: self._help(),
-                        'hosts': lambda _: self._show_hosts(),
+                        'agents': lambda _: self._show_agents(),
                         'sessions': lambda _: self._show_sessions(),
                         'join': lambda c: self._connect_session(cmd),
                         'new': lambda c: self._new_session(cmd)
                     }
                     command = [c for c in commands.keys() if cmd.startswith(c)]
                     await commands[command[0]](cmd)
-            except Exception:
-                self.console.line('Bad command', 'red')
+            except Exception as e:
+                if self.app_svc.config.get('debug'):
+                    traceback.print_exc()
+                self.console.line('Bad command {}'.format(e), 'red')
 
     """ PRIVATE """
 
     @staticmethod
     async def _help():
         print('HELP MENU:')
-        print('-> hosts: show all connected computers')
+        print('-> agents: show all connected computers')
         print('-> sessions: show all active sessions')
-        print('-> new [n]: start a new session on an agent ID')
+        print('-> new [n]: start a new session on an agent idx')
         print('-> join [n]: connect to a session by ID')
 
-    async def _show_hosts(self):
+    async def _sorted_agent_list(self):
+        return sorted(await self.data_svc.locate('agents'), key=lambda a: a.created)
+
+    async def _show_agents(self):
         hosts = []
-        for a in await self.data_svc.locate('agents'):
-            hosts.append(dict(paw=a.paw))
+        for i, a in enumerate(await self._sorted_agent_list()):
+            hosts.append(dict(idx=str(i), host=a.host, user=a.username, priv=a.privilege, paw=a.paw))
         if not hosts:
             self.console.hint('Deploy 54ndc47 agents to add new hosts')
         await self.console.table(hosts)
@@ -71,27 +77,27 @@ class Shell:
             self.console.line('Session cannot be established with %s' % session, 'red')
 
     async def _new_session(self, command):
-        agent_id = command.split(' ')[1]
-        agent = await self.data_svc.locate('agents', match=dict(paw=agent_id))
+        agent_idx = int(command.split(' ')[1])
+        agent = (await self._sorted_agent_list())[agent_idx]
         if agent:
-            match = dict(ability_id='356d1722-7784-40c4-822b-0cf864b0b36d', platform=agent[0].platform)
+            match = dict(ability_id='356d1722-7784-40c4-822b-0cf864b0b36d', platform=agent.platform)
             abilities = await self.data_svc.locate('abilities', match=match)
-            abilities = await agent[0].capabilities(abilities)
-            command = self.planning_svc.decode(abilities[0].test, agent[0], group='')
+            abilities = await agent.capabilities(abilities)
+            command = self.planning_svc.decode(abilities[0].test, agent, group='')
             if abilities[0].cleanup:
-                cleanup = self.planning_svc.decode(abilities[0].cleanup, agent[0], group='')
+                cleanup = self.planning_svc.decode(abilities[0].cleanup, agent, group='')
             else:
                 cleanup = ''
 
-            agents = await self.data_svc.locate('agents', match=dict(group=agent[0].group))
+            agents = await self.data_svc.locate('agents', match=dict(group=agent.group))
             op = await self.data_svc.store(
                 Operation(id='1000', name='terminal', adversary=None, agents=agents)
             )
             op.set_start_details()
             op.add_link(
-                Link(command=self.app_svc.encode_string(command), paw=agent[0].paw, score=0, jitter=0,
+                Link(command=self.app_svc.encode_string(command), paw=agent.paw, score=0, jitter=0,
                      ability=abilities[0], operation=op.id, cleanup=self.app_svc.encode_string(cleanup))
             )
             self.console.line('Queued. Waiting for agent to beacon...', 'green')
         else:
-            self.console.line('No agent with an ID = %s' % agent_id, 'red')
+            self.console.line('No agent found for idx = %s.' % agent_idx, 'red')


### PR DESCRIPTION
Changes:
* use index into a list of agent to connect new shell.
*  display more agent info. 
* replaced the string 'hosts' with 'agents' in some help messages because it fits better. 
* more informative error messages & will print stacktraces if `debug: True` in config file


Depends on: 
https://github.com/mitre/caldera/pull/814